### PR TITLE
Travis configuration included incompatible versions of node.js

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,11 +1,6 @@
 sudo: false
 language: node_js
 node_js:
-  - "0.10"
   - "0.12"
-  - "0.13"
-  - "iojs"
-matrix:
-  fast_finish: true
-  allow_failures:
-    - node_js: "0.13"
+  - "4.0"
+  - "6.0"


### PR DESCRIPTION
0.10 does not support Map
0.13 does not exist
iojs is deprecated and merged into 4.0