### PR TITLE
Use npmjs rather than github ssh.

### DIFF
--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
     "is-windows": "^0.1.0",
     "kind-of": "^2.0.0",
     "lazy-cache": "^0.1.0",
-    "micromatch": "jonschlinkert/micromatch#2.2.0",
+    "micromatch": "2.2.0",
     "mixin-object": "^2.0.0",
     "object-visit": "^0.1.0",
     "object.omit": "^1.1.0",


### PR DESCRIPTION
Resolves https://github.com/micromatch/glob-fs/issues/23

I believe this was all that people were asking for, so that npm isn't trying to use ssh to fetch the repo. This was also an issue when trying to use this package in a docker build where the image didn't include openssh and git packages.

Thanks!